### PR TITLE
move setProperties before put provider

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/JreKeyStoreTest.java
+++ b/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/JreKeyStoreTest.java
@@ -33,13 +33,13 @@ public class JreKeyStoreTest {
     @BeforeAll
     public static void init() {
         /*
-         * Add JCA provider.
-         */
-        PropertyConvertorUtils.addKeyVaultJcaProvider();
-        /*
          * Set system properties.
          */
         PropertyConvertorUtils.putEnvironmentPropertyToSystemPropertyForKeyVaultJca();
+        /*
+         * Add JCA provider.
+         */
+        PropertyConvertorUtils.addKeyVaultJcaProvider();
     }
 
     @Test

--- a/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/ServerSocketTest.java
+++ b/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/ServerSocketTest.java
@@ -49,12 +49,12 @@ public class ServerSocketTest {
 
     @BeforeAll
     public static void beforeEach() throws Exception {
+        PropertyConvertorUtils.putEnvironmentPropertyToSystemPropertyForKeyVaultJca();
         /*
          * Add JCA provider.
          */
         KeyVaultJcaProvider provider = new KeyVaultJcaProvider();
         Security.addProvider(provider);
-        PropertyConvertorUtils.putEnvironmentPropertyToSystemPropertyForKeyVaultJca();
 
         /**
          *  - Create an Azure Key Vault specific instance of a KeyStore.


### PR DESCRIPTION
move setProperties before put provider in keyvault,
when provider can't achieve properties, it won't add Key less signature to provider.